### PR TITLE
ci(gitlab): désactivation temporaire de la pipeline principale 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,11 @@ stages:
   - trigger
   - deploy
 
+# Désactive temporaire des pipelines automatiques
+workflow:
+  rules:
+    - when: never  # Désactive automatiquement
+
 frontend-pipeline:
   stage: trigger
   rules:


### PR DESCRIPTION
Description:
- Désactivation de la pipeline GitLab CI pour limiter l'utilisation crédits
- Les workflows GitHub Actions restent actifs
- À réactiver plus tard si besoin