### PR TITLE
Enable force push for GitLab synchronization

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -21,4 +21,4 @@ jobs:
                   gitlab_url: ${{ secrets.GITLAB_URL }}
                   username: ${{ secrets.USERNAME }}
                   gitlab_pat: ${{ secrets.GITLAB_PAT }}
-                  force_push: false # car force-push interdit sur gitLab main
+                  force_push: true


### PR DESCRIPTION
Changed force_push setting to true for GitLab sync.